### PR TITLE
add sidebar colors

### DIFF
--- a/colors.wt-constants
+++ b/colors.wt-constants
@@ -569,5 +569,17 @@ botKbDownBg: colorLighter0_40;                               // [UNTESTED]:
 // Overview
 overviewCheckBorder: color2;                                 // [UNTESTED]:
 
+// Sidebar
+sideBarBg: color0;
+sideBarBgActive: color2;
+sideBarBgRipple: color1;
+sideBarTextFg: color1;
+sideBarTextFgActive: color7;
+sideBarIconFg: color7;
+sideBarIconFgActive: colorLighter7_40;
+sideBarBadgeBg: color1;
+sideBarBadgeBgMuted: colorDarker7_40;
+sideBarBadgeFg: colorLighter7_40;
+
 // DUNNO
 profileOtherAdminStarFg: color7;                             // [UNTESTED]:


### PR DESCRIPTION
Current version of script doesn't generate sidebar colors so telegram uses defaults. It looks like:
![before](https://i.imgur.com/iNz22jA.png)

I've added colors (based on colors used in others bg/fg), it seems to work:
![after](https://i.imgur.com/9cy5PO6.png)