### PR TITLE
no terminal hanging when using restart option (nohup)

### DIFF
--- a/wal-telegram
+++ b/wal-telegram
@@ -430,7 +430,7 @@ EOF
   fi
   zip -q ${mode}.tdesktop-theme colors.tdesktop-theme ${bg_mode}.jpg
   cp ${mode}.tdesktop-theme "$dest"
-  [ -n "$restart_on_gen" ] && pkill -f telegram-desktop && telegram-desktop & 
+  [ -n "$restart_on_gen" ] && pkill -f telegram-desktop && nohup telegram-desktop &> /dev/null & 
 }
 
 main() {


### PR DESCRIPTION
--restart | -r options hangs the terminal, and when the terminal is closed, telegram will be closed too.
used nohup and redirecting the output to /dev/null so terminal won't be hanged by telegram, and no "nohup.out" file will be produced 