### PR TITLE
resolve bg symlink to absolute path

### DIFF
--- a/wal-telegram
+++ b/wal-telegram
@@ -174,6 +174,7 @@ prepare() {
       fi # if .fehbg exists
     fi # elif mode == palette
   else # if bg == wal
+    bg="$(readlink -f "$bg")"
     bg_ext="${bg##*.}"
     cp "$bg" "${pre}/background.${bg_ext}"
   fi # if bg == wal


### PR DESCRIPTION
faced a problem with symlinks and `wal-telegram`

my files structure is like
```
├── wallpaper -> /home/mrt0rtikize/Pictures/wallpapers/a_girl_red_circle.jpg
└── wallpapers
   ├── a_girl_blue_sky.jpeg
   ├── a_girl_red_circle.jpg
   ├──  ...
```

so in my case wal-telegram doesn't work (cuz symlink has no extension) and i think it's a common case for pywal users

i think what resolving symlinks to absolute path with `readlink` is easiest solution:
- if `bg` is symlink - we will have absolute path instead
- if `bg` is path - it will not change